### PR TITLE
Make the Windows launcher work with Unicode paths

### DIFF
--- a/src/main/cpp/bootstrap/nbexec.exe.manifest
+++ b/src/main/cpp/bootstrap/nbexec.exe.manifest
@@ -48,6 +48,12 @@
       </requestedPrivileges>
      </security>
 </trustInfo>
+<!-- See https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page -->
+<application>
+  <windowsSettings>
+    <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+  </windowsSettings>
+</application>
 <!-- NETBEANS-1227: Indicate the same HiDPI capabilities as javaw.exe from JDK 11. -->
 <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <asmv3:windowsSettings xmlns:dpi1="http://schemas.microsoft.com/SMI/2005/WindowsSettings" xmlns:dpi2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">

--- a/src/main/cpp/bootstrap/utilsfuncs.cpp
+++ b/src/main/cpp/bootstrap/utilsfuncs.cpp
@@ -276,6 +276,19 @@ bool checkLoggingArg(int argc, char *argv[], bool delFile) {
     return true;
 }
 
+void setConsoleCodepage() {
+    /* The Windows console (cmd) has its own code page setting that's usually different from the
+    system and user code page, e.g. on US Windows the console will use code page 437 while the
+    rest of the system uses 1252. Setting the console code page here to UTF-8 makes Unicode
+    characters printed from the application appear correctly. Since the launcher itself also runs
+    with UTF-8 as its code page (specified in the application manifest), this also makes log
+    messages from the launchers appear correctly, e.g. when printing paths that may have Unicode
+    characters in them. Note that if we attached to an existing console, the modified code page
+    setting will persist after the launcher exits. */
+    SetConsoleOutputCP(CP_UTF8);
+    SetConsoleCP(CP_UTF8);
+}
+
 bool setupProcess(int &argc, char *argv[], DWORD &parentProcID, const char *attachMsg) {
 #define CHECK_ARG \
     if (i+1 == argc) {\
@@ -290,6 +303,7 @@ bool setupProcess(int &argc, char *argv[], DWORD &parentProcID, const char *atta
             CHECK_ARG;
             if (strcmp("new", argv[i + 1]) == 0){
                 AllocConsole();
+                setConsoleCodepage();
             } else if (strcmp("suppress", argv[i + 1]) == 0) {
                 // nothing, no console should be attached
             } else {
@@ -332,6 +346,7 @@ bool setupProcess(int &argc, char *argv[], DWORD &parentProcID, const char *atta
                     logErr(true, false, "AttachConsole of PP failed.");
                 } else {
                     getParentProcessID(parentProcID);
+                    setConsoleCodepage();
                     if (attachMsg) {
                         printToConsole(attachMsg);
                     }

--- a/src/main/cpp/harness/app.exe.manifest
+++ b/src/main/cpp/harness/app.exe.manifest
@@ -48,6 +48,12 @@
       </requestedPrivileges>
      </security>
 </trustInfo>
+<!-- See https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page -->
+<application>
+  <windowsSettings>
+    <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+  </windowsSettings>
+</application>
 <!-- NETBEANS-1227: Indicate the same HiDPI capabilities as javaw.exe from JDK 11. -->
 <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <asmv3:windowsSettings xmlns:dpi1="http://schemas.microsoft.com/SMI/2005/WindowsSettings" xmlns:dpi2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">

--- a/src/main/cpp/ide/netbeans.exe.manifest
+++ b/src/main/cpp/ide/netbeans.exe.manifest
@@ -48,6 +48,12 @@
       </requestedPrivileges>
      </security>
 </trustInfo>
+<!-- See https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page -->
+<application>
+  <windowsSettings>
+    <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+  </windowsSettings>
+</application>
 <!-- NETBEANS-1227: Indicate the same HiDPI capabilities as javaw.exe from JDK 11. -->
 <!-- Note that even 32-bit Java 10.0.2 indicates HiDPI-awareness, so it should
      be fine to include it here as well. -->

--- a/src/main/cpp/ide/netbeans64.exe.manifest
+++ b/src/main/cpp/ide/netbeans64.exe.manifest
@@ -50,6 +50,12 @@
       </requestedPrivileges>
      </security>
 </trustInfo>
+<!-- See https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page -->
+<application>
+  <windowsSettings>
+    <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+  </windowsSettings>
+</application>
 <!-- NETBEANS-1227: Indicate the same HiDPI capabilities as javaw.exe from JDK 11. -->
 <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <asmv3:windowsSettings xmlns:dpi1="http://schemas.microsoft.com/SMI/2005/WindowsSettings" xmlns:dpi2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">


### PR DESCRIPTION
On Windows, the `C:\Users\<username>` path will often contain the user's real human name. When this path contains characters outside the current "ANSI code page" (an old DOS concept that predates Unicode), lots of different things break, and NetBeans will fail to work. See https://github.com/apache/netbeans/issues/4314. Users have no way to rename this directory.

The underlying problem is that both OpenJDK and the NetBeans launcher, like most old Windows software, tend to use the "ANSI" versions of Win32 APIs rather than the "Wide Char" versions (e.g. GetCurrentDirectoryA instead of GetCurrentDirectoryW). About 3 years ago, Microsoft started recommending an easy solution: Rather than replacing "char *" with "wchar_t *" everywhere, we can now set UTF-8 as the default "code page" for all ANSI Win32 API calls, at the EXE file process level. We do this here for the NetBeans Windows launcher. See https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page

Since the NetBeans Windows launcher uses JNI to start Java in-process, the JVM inherits the same default code page setting, without the user having to change regional settings in the Control Panel. Everything then works consistently; passing of system properties into the JVM, loading of libraries from Unicode paths from the system classloader or Java Native Access, and so on. This assumes that OpenJDK takes its Win32 code page setting from the "user" locale (the GetACP() Win32 function) rather than the "system" locale. This been explicitly the case since https://bugs.openjdk.org/browse/JDK-8272352, in Java 19 and recent backports to Java 11.0.17 and Java 17.0.5.

We also set the UTF-8 code page for the windows console, so that Unicode characters display correctly there.

On the aforementioned recent Java versions, NetBeans should now run fine when there are Unicode characters in the NetBeans installation path, the JDK path, the user/cache directory paths, or in the java.io.tmpdir path (the latter sometimes being a problem for JNA, which is used by FlatLAF). This was tested on Java 17.0.5 with Cyrillic and Norwegian characters in the OS home directory path and all of the paths above, with different combinations of Cyrillic vs. US English code pages set at the user vs. system level ("Formats/Format" vs. "Administrative/Change System Locale" in the "Region" control panel dialog). Both the NetBeans IDE launcher and a NetBeans Platform application launcher were tested.