### PR TITLE
Forcing restart when to_enable.txt file exists.

### DIFF
--- a/src/main/cpp/bootstrap/jvmlauncher.cpp
+++ b/src/main/cpp/bootstrap/jvmlauncher.cpp
@@ -249,7 +249,7 @@ bool JvmLauncher::startInProcJvm(const char *mainClassName, const std::list<std:
             for (list<string>::const_iterator it = options.begin(); it != options.end(); ++it, ++i) {
                 const string &option = *it;
                 logMsg("\t%s", option.c_str());
-                if (option.find("-splash:") == 0 && hSplash > 0) {
+                if (option.find("-splash:") == 0 && hSplash != NULL) {
                     const string splash = option.substr(8);
                     logMsg("splash at %s", splash.c_str());
                     

--- a/src/main/cpp/bootstrap/platformlauncher.cpp
+++ b/src/main/cpp/bootstrap/platformlauncher.cpp
@@ -485,6 +485,15 @@ bool PlatformLauncher::shouldAutoUpdate(bool firstStart, const char *basePath) {
         }
 
         path = basePath;
+        path += "\\update\\deactivate\\to_enable.txt";
+        hFind = FindFirstFile(path.c_str(), &fd);
+        if (hFind != INVALID_HANDLE_VALUE) {
+            logMsg("to_enable.txt found: %s", path.c_str());
+            FindClose(hFind);
+            return true;
+        }
+
+        path = basePath;
         path += "\\update\\deactivate\\to_uninstall.txt";
         hFind = FindFirstFile(path.c_str(), &fd);
         if (hFind != INVALID_HANDLE_VALUE) {


### PR DESCRIPTION
As part of:
https://github.com/apache/netbeans/pull/6743

I am proposing to add an ability to enable module fragments. This requires a restart, and the modules-to-be-enabled must be written to a file (as are modules-to-be-disabled). This patch adds support for such a file, `to_enable.txt`.

Also fixes a pointer comparison which a new gcc rejects.
