### PR TITLE
Propagate NETBEANS_USERDIR environment variable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,19 +73,20 @@ under the License.
                         </goals>
                         <configuration>
                             <target>
-                                <exec executable="make" dir="src/main/cpp/bootstrap">
+                                <exec executable="make" failonerror="true" dir="src/main/cpp/bootstrap">
                                     <arg value="-f" />
                                     <arg value="Makefile.mingw" />
                                 </exec>
-                                <exec executable="make" dir="src/main/cpp/ide">
+                                <exec executable="make" failonerror="true" dir="src/main/cpp/ide">
                                     <arg value="-f" />
                                     <arg value="Makefile.mingw" />
                                 </exec>
-                                <exec executable="make" dir="src/main/cpp/harness">
+                                <exec executable="make" failonerror="true" dir="src/main/cpp/harness">
                                     <arg value="-f" />
                                     <arg value="Makefile.mingw" />
                                 </exec>
                             </target>
+                            <failOnError>true</failOnError>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/cpp/bootstrap/jvmlauncher.cpp
+++ b/src/main/cpp/bootstrap/jvmlauncher.cpp
@@ -249,7 +249,7 @@ bool JvmLauncher::startInProcJvm(const char *mainClassName, const std::list<std:
             for (list<string>::const_iterator it = options.begin(); it != options.end(); ++it, ++i) {
                 const string &option = *it;
                 logMsg("\t%s", option.c_str());
-                if (option.find("-splash:") == 0 && hSplash > 0) {
+                if (option.find("-splash:") == 0 && hSplash) {
                     const string splash = option.substr(8);
                     logMsg("splash at %s", splash.c_str());
                     


### PR DESCRIPTION
- this is the "Windows part" of https://github.com/apache/netbeans/pull/8756
- TBD: it updates the `netbeans*.exe` launcher to behave the same as Unix one
- first of all it makes the `mvn install` fail when the C++ compilation fails